### PR TITLE
Using standard xml.etree by default and fallback to lxml if that is not ...

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -8,7 +8,10 @@ See LICENSE for licensing information.
 '''
 
 import logging
-from lxml import etree
+try:
+    from xml.etree import ElementTree as etree
+except ImportError:
+    from lxml import etree
 try:
     from PIL import Image
 except ImportError:


### PR DESCRIPTION
The lxml is a separate library while xml.etree is part of standard python deployment. I, therefore, propose slight change in the code for ease of deployment.
