### PR TITLE
One should be able to attach images to document without copying them to template dir.

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -33,31 +33,31 @@ if not os.path.isdir(template_dir):
 # make it easier to copy Word output more easily.
 nsprefixes = {
     # Text Content
-    'mv':'urn:schemas-microsoft-com:mac:vml',
-    'mo':'http://schemas.microsoft.com/office/mac/office/2008/main',
-    've':'http://schemas.openxmlformats.org/markup-compatibility/2006',
-    'o':'urn:schemas-microsoft-com:office:office',
-    'r':'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
-    'm':'http://schemas.openxmlformats.org/officeDocument/2006/math',
-    'v':'urn:schemas-microsoft-com:vml',
-    'w':'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
-    'w10':'urn:schemas-microsoft-com:office:word',
-    'wne':'http://schemas.microsoft.com/office/word/2006/wordml',
+    'mv': 'urn:schemas-microsoft-com:mac:vml',
+    'mo': 'http://schemas.microsoft.com/office/mac/office/2008/main',
+    've': 'http://schemas.openxmlformats.org/markup-compatibility/2006',
+    'o': 'urn:schemas-microsoft-com:office:office',
+    'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+    'm': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+    'v': 'urn:schemas-microsoft-com:vml',
+    'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+    'w10': 'urn:schemas-microsoft-com:office:word',
+    'wne': 'http://schemas.microsoft.com/office/word/2006/wordml',
     # Drawing
-    'wp':'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
-    'a':'http://schemas.openxmlformats.org/drawingml/2006/main',
-    'pic':'http://schemas.openxmlformats.org/drawingml/2006/picture',
+    'wp': 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+    'a': 'http://schemas.openxmlformats.org/drawingml/2006/main',
+    'pic': 'http://schemas.openxmlformats.org/drawingml/2006/picture',
     # Properties (core and extended)
-    'cp':"http://schemas.openxmlformats.org/package/2006/metadata/core-properties",
-    'dc':"http://purl.org/dc/elements/1.1/",
-    'dcterms':"http://purl.org/dc/terms/",
-    'dcmitype':"http://purl.org/dc/dcmitype/",
-    'xsi':"http://www.w3.org/2001/XMLSchema-instance",
-    'ep':'http://schemas.openxmlformats.org/officeDocument/2006/extended-properties',
+    'cp': 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties',
+    'dc': 'http://purl.org/dc/elements/1.1/',
+    'dcterms': 'http://purl.org/dc/terms/',
+    'dcmitype': 'http://purl.org/dc/dcmitype/',
+    'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    'ep': 'http://schemas.openxmlformats.org/officeDocument/2006/extended-properties',
     # Content Types (we're just making up our own namespaces here to save time)
-    'ct':'http://schemas.openxmlformats.org/package/2006/content-types',
+    'ct': 'http://schemas.openxmlformats.org/package/2006/content-types',
     # Package Relationships (we're just making up our own namespaces here to save time)
-    'pr':'http://schemas.openxmlformats.org/package/2006/relationships'
+    'pr': 'http://schemas.openxmlformats.org/package/2006/relationships',
     }
 
 image_relationship = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'

--- a/docx.py
+++ b/docx.py
@@ -387,8 +387,12 @@ def picture(relationshiplist, picpath, picdescription, pixelwidth=None,
 
     # Set relationship ID to the first available
     picid = '2'
-    picrelid = 'rId' + str(len(relationshiplist) + 1)
-    relationshiplist.append([image_relationship, picpath])
+    try:
+        relid = (idx for idx, rel in enumerate(relationshiplist) if rel[1] == picpath).next() + 1
+    except StopIteration:
+        relationshiplist.append([image_relationship, picpath])
+        relid = len(relationshiplist)
+    picrelid = 'rId' + str(relid)
 
     # There are 3 main elements inside a picture
     # 1. The Blipfill - specifies how the image fills the picture area (stretch, tile, etc.)

--- a/docx.py
+++ b/docx.py
@@ -61,6 +61,7 @@ nsprefixes = {
     }
 
 image_relationship = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'
+hlink_relationship = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink' 
 
 def opendocx(file):
     '''Open a docx file, return a document XML tree'''
@@ -841,8 +842,11 @@ def wordrelationships(relationshiplist):
 
     for idx, relationship in enumerate(relationshiplist):
         # Relationship IDs (rId) start at 1.
-        relationships.append(makeelement('Relationship', attributes={'Id': 'rId' + str(idx + 1),
-        'Type': relationship[0],'Target': relationship[1]}, nsprefix=None))
+        element = makeelement('Relationship', attributes={'Id': 'rId' + str(idx + 1),
+                              'Type': relationship[0],'Target': relationship[1]}, nsprefix=None)
+        if relationship[0] == hlink_relationship:
+            element.attrib['TargetMode'] = 'External'
+        relationships.append(element)
     
     return relationships
 

--- a/example-makedocument.py
+++ b/example-makedocument.py
@@ -73,7 +73,6 @@ if __name__ == '__main__':
     appprops = appproperties()
     contenttypes = contenttypes()
     websettings = websettings()
-    wordrelationships = wordrelationships(relationships)
-    
+
     # Save our document
-    savedocx(document,coreprops,appprops,contenttypes,websettings,wordrelationships,'Welcome to the Python docx module.docx')
+    savedocx(document,coreprops,appprops,contenttypes,websettings,relationships,'Welcome to the Python docx module.docx')


### PR DESCRIPTION
It is inconvenient to always have images in current dir in order to attach them to document. It is also not always possible to copy image to the templates because of file rights. Moreover, it looks like media directory is never cleaned out. 

As there is no real reason to copy images to templates in order to store them in docx file, I propose these changes to merge.  Full image paths are stored in relationshiplist, and are copied directly to zip file in savedocx. picture now accepts full paths, and savedocx accepts relationshiplist instead of wordrelationshiplist.
