### PR TITLE
changing from os.mkdir() to os.makedirs()

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -409,7 +409,7 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
     # Copy the file into the media dir
     media_dir = join(template_dir, 'word', 'media')
     if not os.path.isdir(media_dir):
-        os.mkdir(media_dir)
+        os.makedirs(media_dir)
     shutil.copyfile(picname, join(media_dir, picname))
 
     # Check if the user has specified a size


### PR DESCRIPTION
If the path template/word/ doesn't exists the creation of template/word/media wouldn't be created since os.mkdir() doesn't create the intermetidate directories. os.makedirs() does it.
