### PR TITLE
Switch setup.py to setuptools for better dependency installation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,6 +52,15 @@ Thanks to the awesomeness of the lxml module, we can:
 
 Congratulations, you just made and then modified a Word document!
 
+Alternatively, if you have setuptools and pip, you can run `pip
+install docx` to install the package and its dependencies, and
+download
+[example-makedocument.py](https://raw.github.com/mikemaccana/python-docx/master/example-makedocument.py)
+and
+[example-extracttext.py](https://raw.github.com/mikemaccana/python-docx/master/example-extracttext.py)
+to test them out. Note that lxml requires that libxml2-dev and
+libxslt1-dev are installed.
+
 ## Extracting Text from a Document
 
 If you just want to extract the text from a Word file, run: 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:    
+    from distutils.core import setup
 from glob import glob
 
 # Make data go into site-packages (http://tinyurl.com/site-pkg)
@@ -10,7 +13,7 @@ for scheme in INSTALL_SCHEMES.values():
 
 setup(name='docx',
       version='0.2.0',
-      requires=['lxml'],
+      install_requires=['lxml', 'PIL'],
       description='The docx module creates, reads and writes Microsoft Office Word 2007 docx files',
       author='Mike MacCana',
       author_email='python.docx@librelist.com',


### PR DESCRIPTION
Current setup.py file doesn't install dependencies correctly when using 'pip install docx'. This should fix that.
