### PR TITLE
Add an example showing italic text.

### DIFF
--- a/example-makedocument.py
+++ b/example-makedocument.py
@@ -37,8 +37,8 @@ if __name__ == '__main__':
              ]
     for point in points:
         body.append(paragraph(point, style='ListNumber'))
-    body.append(paragraph('For those of us who prefer something simpler, I '
-                          'made docx.'))
+    body.append(paragraph([('For those of us who prefer something simpler, I '
+                          'made docx.', 'i')]))    
     body.append(heading('Making documents', 2))
     body.append(paragraph('The docx module has the following features:'))
 


### PR DESCRIPTION
The doc-string of `paragraph` does show this, but having an example helps users who don't look at the source.
