### PR TITLE
Handling image files: prevent accumulation in template, jpeg orientation and template correction

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -27,6 +27,9 @@ try:
 except ImportError:
     TAGS = {}
 
+from exceptions import PendingDeprecationWarning
+from warnings import warn
+
 import logging
 
 
@@ -412,6 +415,9 @@ def table(contents, heading=True, colw=None, cwunit='dxa', tblw=0, twunit='auto'
 def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelheight=None, nochangeaspect=True, nochangearrowheads=True, imagefiledict=None):
     '''Take a relationshiplist, picture file name, and return a paragraph containing the image
     and an updated relationshiplist'''
+    if imagefiledict is None:
+        warn('Using picture() without imagefiledict parameter will be deprecated in the future.', PendingDeprecationWarning)
+
     # http://openxmldeveloper.org/articles/462.aspx
     # Create an image. Size may be specified, otherwise it will based on the
     # pixel size of image. Return a paragraph containing the picture
@@ -965,6 +971,9 @@ def wordrelationships(relationshiplist):
 
 def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelationships, output, imagefiledict=None):
     '''Save a modified document'''
+    if imagefiledict is None:
+        warn('Using savedocx() without imagefiledict parameter will be deprecated in the future.', PendingDeprecationWarning)
+
     assert os.path.isdir(template_dir)
     docxfile = zipfile.ZipFile(output, mode='w', compression=zipfile.ZIP_DEFLATED)
 

--- a/docx.py
+++ b/docx.py
@@ -423,14 +423,13 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
     if imagefiledict is not None:
         # Keep track of the image files in a separate dictionary so they don't
         # need to be copied into the template directory
-
         if picpath not in imagefiledict:
-            picrelid = 'rId' + str(len(imagefiledict.keys()) + 1)
+            picrelid = 'rId' + str(len(relationshiplist) + 1)
             imagefiledict[picpath] = picrelid
 
             relationshiplist.append([
                 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
-                'media/' + basename(picpath)])
+                'media/%s_%s' % (picrelid, basename(picpath))])
         else:
             picrelid = imagefiledict[picpath]
     else:
@@ -492,7 +491,7 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
     # 2. The non visual picture properties
     nvpicpr = makeelement('nvPicPr', nsprefix='pic')
     cnvpr = makeelement('cNvPr', nsprefix='pic',
-                        attributes={'id': '0', 'name': 'Picture 1', 'descr': picname})
+                        attributes={'id': '0', 'name': 'Picture 1', 'descr': picdescription})
     nvpicpr.append(cnvpr)
     cnvpicpr = makeelement('cNvPicPr', nsprefix='pic')
     cnvpicpr.append(makeelement('picLocks', nsprefix='a',
@@ -987,8 +986,8 @@ def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelat
 
     # Add & compress images, if applicable
     if imagefiledict is not None:
-        for imagepath in imagefiledict.keys():
-            archivename = 'word/media/' + basename(imagepath)
+        for imagepath, picrelid in imagefiledict.items():
+            archivename = 'word/media/%s_%s' % (picrelid, basename(imagepath))
             log.info('Saving: %s', archivename)
             docxfile.write(imagepath, archivename)
 

--- a/docx.py
+++ b/docx.py
@@ -19,7 +19,7 @@ import shutil
 import re
 import time
 import os
-from os.path import join
+from os.path import join, basename, abspath
 
 log = logging.getLogger(__name__)
 
@@ -400,17 +400,42 @@ def table(contents, heading=True, colw=None, cwunit='dxa', tblw=0, twunit='auto'
     return table
 
 
-def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelheight=None, nochangeaspect=True, nochangearrowheads=True):
+def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelheight=None, nochangeaspect=True, nochangearrowheads=True, imagefiledict=None):
     '''Take a relationshiplist, picture file name, and return a paragraph containing the image
     and an updated relationshiplist'''
     # http://openxmldeveloper.org/articles/462.aspx
     # Create an image. Size may be specified, otherwise it will based on the
-    # pixel size of image. Return a paragraph containing the picture'''
-    # Copy the file into the media dir
-    media_dir = join(template_dir, 'word', 'media')
-    if not os.path.isdir(media_dir):
-        os.mkdir(media_dir)
-    shutil.copyfile(picname, join(media_dir, picname))
+    # pixel size of image. Return a paragraph containing the picture
+
+    # Set relationship ID to that of the image or the first available one
+    picid = '2'
+    if imagefiledict is not None:
+        # Keep track of the image files in a separate dictionary so they don't
+        # need to be copied into the template directory
+        picpath = abspath(picname)
+
+        if picpath not in imagefiledict:
+            picrelid = 'rId' + str(len(imagefiledict.keys()) + 1)
+            imagefiledict[picpath] = picrelid
+
+            relationshiplist.append([
+                'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
+                'media/' + basename(picpath)])
+        else:
+            picrelid = imagefiledict[picpath]
+    else:
+        # Copy files into template directory for backwards compatibility
+        # Images still accumulate in the template directory this way
+        picrelid = 'rId' + str(len(relationshiplist) + 1)
+
+        relationshiplist.append([
+            'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
+            'media/' + picname])
+
+        media_dir = join(template_dir, 'word', 'media')
+        if not os.path.isdir(media_dir):
+            os.mkdir(media_dir)
+        shutil.copyfile(picname, join(media_dir, picname))
 
     # Check if the user has specified a size
     if not pixelwidth or not pixelheight:
@@ -422,13 +447,6 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
     emuperpixel = 12700
     width = str(pixelwidth * emuperpixel)
     height = str(pixelheight * emuperpixel)
-
-    # Set relationship ID to the first available
-    picid = '2'
-    picrelid = 'rId'+str(len(relationshiplist)+1)
-    relationshiplist.append([
-        'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
-        'media/'+picname])
 
     # There are 3 main elements inside a picture
     # 1. The Blipfill - specifies how the image fills the picture area (stretch, tile, etc.)
@@ -502,7 +520,11 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
     run.append(drawing)
     paragraph = makeelement('p')
     paragraph.append(run)
-    return relationshiplist, paragraph
+
+    if imagefiledict is not None:
+        return relationshiplist, paragraph, imagefiledict
+    else:
+        return relationshiplist, paragraph
 
 
 def search(document, search):
@@ -909,7 +931,7 @@ def wordrelationships(relationshiplist):
     return relationships
 
 
-def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelationships, output):
+def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelationships, output, imagefiledict=None):
     '''Save a modified document'''
     assert os.path.isdir(template_dir)
     docxfile = zipfile.ZipFile(output, mode='w', compression=zipfile.ZIP_DEFLATED)
@@ -930,6 +952,13 @@ def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelat
         treestring = etree.tostring(tree, pretty_print=True)
         docxfile.writestr(treesandfiles[tree], treestring)
 
+    # Add & compress images, if applicable
+    if imagefiledict is not None:
+        for imagepath in imagefiledict.keys():
+            archivename = 'word/media/' + basename(imagepath)
+            log.info('Saving: %s', archivename)
+            docxfile.write(imagepath, archivename)
+
     # Add & compress support files
     files_to_ignore = ['.DS_Store']  # nuisance from some os's
     for dirpath, dirnames, filenames in os.walk('.'):
@@ -940,6 +969,7 @@ def savedocx(document, coreprops, appprops, contenttypes, websettings, wordrelat
             archivename = templatefile[2:]
             log.info('Saving: %s', archivename)
             docxfile.write(templatefile, archivename)
+
     log.info('Saved new file to: %r', output)
     docxfile.close()
     os.chdir(prev_dir)  # restore previous working dir

--- a/docx.py
+++ b/docx.py
@@ -8,18 +8,27 @@ Part of Python's docx module - http://github.com/mikemaccana/python-docx
 See LICENSE for licensing information.
 """
 
-import logging
+import os
+import re
+import time
+import shutil
+import zipfile
+
 from lxml import etree
+from os.path import abspath, basename, join
+
 try:
     from PIL import Image
 except ImportError:
     import Image
-import zipfile
-import shutil
-import re
-import time
-import os
-from os.path import join, basename, abspath
+
+try:
+    from PIL.ExifTags import TAGS
+except ImportError:
+    TAGS = {}
+
+import logging
+
 
 log = logging.getLogger(__name__)
 
@@ -409,10 +418,11 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
 
     # Set relationship ID to that of the image or the first available one
     picid = '2'
+    picpath = abspath(picname)
+
     if imagefiledict is not None:
         # Keep track of the image files in a separate dictionary so they don't
         # need to be copied into the template directory
-        picpath = abspath(picname)
 
         if picpath not in imagefiledict:
             picrelid = 'rId' + str(len(imagefiledict.keys()) + 1)
@@ -437,10 +447,31 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
             os.mkdir(media_dir)
         shutil.copyfile(picname, join(media_dir, picname))
 
+    image = Image.open(picpath)
+
+    # Extract EXIF data, if available
+    imageExif = {}
+    try:
+        exif = image._getexif()
+    except:
+        exif = {}
+
+    for tag, value in exif.items():
+        imageExif[TAGS.get(tag, tag)] = value
+
+    imageOrientation = imageExif.get('Orientation', 1)
+    imageAngle = { 1: 0, 2: 0, 3: 180, 4: 0, 5: 90, 6: 90, 7: 270, 8: 270}[imageOrientation]
+    imageFlipH = 'true' if imageOrientation in (2, 5, 7) else 'false'
+    imageFlipV = 'true' if imageOrientation == 4 else 'false'
+
     # Check if the user has specified a size
     if not pixelwidth or not pixelheight:
         # If not, get info from the picture itself
-        pixelwidth, pixelheight = Image.open(picname).size[0:2]
+        pixelwidth, pixelheight = image.size[0:2]
+
+    # Swap width and height if necessary
+    if imageOrientation in (5, 6, 7, 8):
+        pixelwidth, pixelheight = pixelheight, pixelwidth
 
     # OpenXML measures on-screen objects in English Metric Units
     # 1cm = 36000 EMUs
@@ -471,7 +502,9 @@ def picture(relationshiplist, picname, picdescription, pixelwidth=None, pixelhei
 
     # 3. The Shape properties
     sppr = makeelement('spPr', nsprefix='pic', attributes={'bwMode': 'auto'})
-    xfrm = makeelement('xfrm', nsprefix='a')
+    xfrm = makeelement('xfrm', nsprefix='a',
+                       attributes={'rot': str(imageAngle * 60000),
+                                   'flipH': imageFlipH, 'flipV': imageFlipV})
     xfrm.append(makeelement('off', nsprefix='a', attributes={'x': '0', 'y': '0'}))
     xfrm.append(makeelement('ext', nsprefix='a', attributes={'cx': width, 'cy': height}))
     prstgeom = makeelement('prstGeom', nsprefix='a', attributes={'prst': 'rect'})

--- a/template/_rels/.rels
+++ b/template/_rels/.rels
@@ -9,6 +9,4 @@
 
 	<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officedocument/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
 
-	<Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
-
 </Relationships>

--- a/tests/test_docx.py
+++ b/tests/test_docx.py
@@ -22,9 +22,10 @@ def teardown_module():
     if TEST_FILE in os.listdir('.'):
         os.remove(TEST_FILE)
 
-def simpledoc():
+def simpledoc(noimagecopy=False):
     '''Make a docx (document, relationships) for use in other docx tests'''
     relationships = relationshiplist()
+    imagefiledict = {}
     document = newdocument()
     docbody = document.xpath('/w:document/w:body', namespaces=nsprefixes)[0]
     docbody.append(heading('Heading 1',1)  )   
@@ -36,11 +37,17 @@ def simpledoc():
     docbody.append(paragraph('Paragraph 2')) 
     docbody.append(table([['A1','A2','A3'],['B1','B2','B3'],['C1','C2','C3']]))
     docbody.append(pagebreak(type='section', orient='portrait'))
-    relationships,picpara = picture(relationships,IMAGE1_FILE,'This is a test description')
+    if noimagecopy:
+        relationships,picpara,imagefiledict = picture(relationships,IMAGE1_FILE,'This is a test description', imagefiledict=imagefiledict)
+    else:
+        relationships,picpara = picture(relationships,IMAGE1_FILE,'This is a test description')
     docbody.append(picpara)
     docbody.append(pagebreak(type='section', orient='landscape'))
     docbody.append(paragraph('Paragraph 3'))
-    return (document, docbody, relationships)
+    if noimagecopy:
+        return (document, docbody, relationships, imagefiledict)
+    else:
+        return (document, docbody, relationships)
 
 
 # --- Test Functions ---
@@ -56,7 +63,7 @@ def testsearchandreplace():
     if search(docbody, 'Paragraph 2'): 
         docbody = replace(docbody,'Paragraph 2','Whacko 55') 
     assert search(docbody, 'Whacko 55')
-    
+
 def testtextextraction():
     '''Ensure text can be pulled out of a document'''
     document = opendocx(TEST_FILE)
@@ -72,12 +79,18 @@ def testunsupportedpagebreak():
     except ValueError:
         return # passed
     assert False # failed
-    
+
 def testnewdocument():
     '''Test that a new document can be created'''
     document, docbody, relationships = simpledoc()
     coreprops = coreproperties('Python docx testnewdocument','A short example of making docx from Python','Alan Brooks',['python','Office Open XML','Word'])
     savedocx(document, coreprops, appproperties(), contenttypes(), websettings(), wordrelationships(relationships), TEST_FILE)
+
+def testnewdocument_noimagecopy():
+    '''Test that a new document can be created'''
+    document, docbody, relationships, imagefiledict = simpledoc(noimagecopy=True)
+    coreprops = coreproperties('Python docx testnewdocument','A short example of making docx from Python','Alan Brooks',['python','Office Open XML','Word'])
+    savedocx(document, coreprops, appproperties(), contenttypes(), websettings(), wordrelationships(relationships), TEST_FILE, imagefiledict=imagefiledict)
 
 def testopendocx():
     '''Ensure an etree element is returned'''


### PR DESCRIPTION
As issues #23 and #38 already point out, the accumulation of image files in the template is undesired behavior. I propose these changes as a solution, beside some other minor improvements.

Since the proposed changes with issue #23 were rejected for not being backward compatible and because of the desired functional coding style, there was little room for a complete solution; the unique file paths do need to get across from `picture()` to `savedocx()`. Therefor I propose adding an extra parameter and return value to `picture()` and `savedocx()`, containing the unique image paths to be added to the docx file. The `imagefiledict` parameter is made optional because of backward compatibility. However, this does revert to copying the images into the template directory.
(I have taken the liberty to suggest a `PendingDeprecationWarning` when `picture()` or `savedocx()` are called without the `imagefiledict` parameter.)

The other minor improvements consist of applying the orientation information in EXIF data, if available, to the `xfrm` element, and the removal of an undesired relation in the template.

P.S. Please feel free to indicate wishes regarding the proposed changes.
