### PR TITLE
Allow path of source picture to be specified in picture()

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -420,7 +420,7 @@ def table(contents, heading=True, colw=None, cwunit='dxa', tblw=0,
 
 
 def picture(
-        relationshiplist, picname, picdescription, pixelwidth=None,
+        relationshiplist, filepath, picname, picdescription, pixelwidth=None,
         pixelheight=None, nochangeaspect=True, nochangearrowheads=True):
     """
     Take a relationshiplist, picture file name, and return a paragraph
@@ -433,7 +433,7 @@ def picture(
     media_dir = join(template_dir, 'word', 'media')
     if not os.path.isdir(media_dir):
         os.mkdir(media_dir)
-    shutil.copyfile(picname, join(media_dir, picname))
+    shutil.copyfile(join(filepath, picname), join(media_dir, picname))
 
     # Check if the user has specified a size
     if not pixelwidth or not pixelheight:


### PR DESCRIPTION
The existing picture() method assumes the source file to be in the current directory.

This patch adds a parameter to specify the path of the source picture.
