### PR TITLE
Fix issue with relative paths to image files (images not incorporated into document)

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -430,6 +430,20 @@ def table(contents, heading=True, colw=None, cwunit='dxa', tblw=0,
         table.append(row)
     return table
 
+def slugify_with_ext(value):
+    """
+    Normalizes string, converts to lowercase, removes non-alpha characters,
+    and converts spaces to hyphens.
+    Based loosely on Django as described by S.Lott posted to 
+    http://stackoverflow.com/a/295466/527489
+    """
+    file_name, file_ext = os.path.splitext(value)
+    import unicodedata
+    file_name = unicodedata.normalize('NFKD', unicode(file_name)).encode('ascii', 'ignore')
+    file_name = unicode(re.sub('[^\w\s-]', '', file_name).strip().lower())
+    re.sub('[-\s]+', '-', file_name)
+    slug_plus_ext = ''.join((file_name, file_ext))
+    return slug_plus_ext
 
 def picture(
         relationshiplist, picname, picdescription, pixelwidth=None,
@@ -474,13 +488,13 @@ def picture(
 
         relationshiplist.append([
             'http://schemas.openxmlformats.org/officeDocument/2006/relations'
-            'hips/image', 'media/' + picname
+            'hips/image', 'media/' + slugify_with_ext(picname)
         ])
 
         media_dir = join(template_dir, 'word', 'media')
         if not os.path.isdir(media_dir):
             os.mkdir(media_dir)
-        shutil.copyfile(picname, join(media_dir, picname))
+        shutil.copyfile(picname, join(media_dir, slugify_with_ext(picname)))
 
     image = Image.open(picpath)
 


### PR DESCRIPTION
For your consideration...  (I'm sure another, better slugify option must exist - for one thing, this reveals some info about local paths in resulting zip/docx)

The issues I saw were that:
- images specified with relative file names would not get into document
- it looked to me like two images with same names but with different paths _might_ collide  (*I did not test this specifically)

To reproduce the bug, you can use commit 51aa224 of http://github.com/ransage/csv2docx/
(that commit has a crude, hard-coded test case, which is set up to work with virtualenv)
