### PR TITLE
Throw an exception if the docx file is invalid.

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -77,11 +77,19 @@ nsprefixes = {
     'dcmitype': 'http://purl.org/dc/dcmitype/',
     'dcterms':  'http://purl.org/dc/terms/'}
 
+class BaseDocxError(Exception):
+    pass
+
+class BadDocxFile(BaseDocxError):
+    pass
 
 def opendocx(file):
     '''Open a docx file, return a document XML tree'''
-    mydoc = zipfile.ZipFile(file)
-    xmlcontent = mydoc.read('word/document.xml')
+    try:
+        mydoc = zipfile.ZipFile(file)
+        xmlcontent = mydoc.read('word/document.xml')
+    except (zipfile.BadZipfile, KeyError):
+        raise BadDocxFile("File is not a docx file")
     document = etree.fromstring(xmlcontent)
     return document
 


### PR DESCRIPTION
Right now if the file is a doc file (i.e. not a zip file) it throws a zipfile.BadZipFile exception, and if it's a zip file missing the right xml files it throws a KeyError. This catches both exceptions and throws a more useful exception that can be caught by a function/tool using python-docx.
