### PR TITLE
Added python 3 support and fixed small bug with picture appending

### DIFF
--- a/docx.py
+++ b/docx.py
@@ -27,7 +27,11 @@ try:
 except ImportError:
     TAGS = {}
 
-from exceptions import PendingDeprecationWarning
+try:
+    from exceptions import PendingDeprecationWarning
+except ImportError:
+    pass
+
 from warnings import warn
 
 import logging
@@ -349,7 +353,10 @@ def table(contents, heading=True, colw=None, cwunit='dxa', tblw=0,
                 k = 'all' if 'all' in borders.keys() else b
                 attrs = {}
                 for a in borders[k].keys():
-                    attrs[a] = unicode(borders[k][a])
+                    try:
+                        attrs[a] = unicode(borders[k][a])
+                    except NameError:
+                        attrs[a] = str(borders[k][a])
                 borderelem = makeelement(b, attributes=attrs)
                 tableborders.append(borderelem)
         tableprops.append(tableborders)
@@ -977,11 +984,16 @@ def appproperties():
 
     """
     appprops = makeelement('Properties', nsprefix='ep')
-    appprops = etree.fromstring(
+    appprops_content = (
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Properties x'
         'mlns="http://schemas.openxmlformats.org/officeDocument/2006/extended'
         '-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocum'
-        'ent/2006/docPropsVTypes"></Properties>')
+        'ent/2006/docPropsVTypes"></Properties>'
+    )
+    try:
+        appprops = etree.fromstring(appprops_content)
+    except ValueError:
+        appprops = etree.fromstring(appprops_content.encode('utf-8'))
     props =\
         {'Template':             'Normal.dotm',
          'TotalTime':            '6',

--- a/docx.py
+++ b/docx.py
@@ -481,13 +481,13 @@ def picture(
 
         relationshiplist.append([
             'http://schemas.openxmlformats.org/officeDocument/2006/relations'
-            'hips/image', 'media/' + picname
+            'hips/image', 'media/' + basename(picname)
         ])
 
         media_dir = join(template_dir, 'word', 'media')
         if not os.path.isdir(media_dir):
             os.mkdir(media_dir)
-        shutil.copyfile(picname, join(media_dir, picname))
+        shutil.copyfile(picname, join(media_dir, basename(picname)))
 
     image = Image.open(picpath)
 


### PR DESCRIPTION
Hi! Thanks for great work! It saved my time!

I've added python 3 support and fix bug with picture appending: picname variable contains full path to picture, but in some cases we use it as name of file (not path). For example, we had
shutil.copyfile(picname, join(media_dir, picname))
media_dir can contain something like 'PROJECT_DIR/media/'
picname can contain something like 'PROJECT_DIR/some_another_dir/1.jpg'
os.path.join(media_dir, picname) will return 'PROJECT_DIR/some_another_dir/1.jpg', but it's not what we need! 
